### PR TITLE
Update version to 0.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath "net.alchim31.gradle:gradle-getdown-plugin:0.2.0"
+    classpath "net.alchim31.gradle:gradle-getdown-plugin:0.4.4"
   }
 }
 


### PR DESCRIPTION
The example still uses version 0.2.0. To allow for easier copy-and-paste
startup, bump version to the latest one (0.4.4)