### PR TITLE
Auto-detect and use HTTP-Proxy

### DIFF
--- a/src/main/groovy/bundles/JreTools.groovy
+++ b/src/main/groovy/bundles/JreTools.groovy
@@ -3,6 +3,8 @@ package bundles
 import com.squareup.okhttp.OkHttpClient
 import com.squareup.okhttp.Request
 
+import java.net.Proxy;
+
 //TODO add testcase
 public class JreTools {
 	public static JreVersion current() {
@@ -37,12 +39,31 @@ public class JreTools {
 		"java_vm"
 	}
 
+	private static def isHttpProxyConfigured() {
+		return null != System.getProperty("http.proxyHost") &&
+			null != System.getProperty("http.proxyPort");
+	}
+	
 	//see https://ivan-site.com/2012/05/download-oracle-java-jre-jdk-using-a-script/
 	//TODO run async download
 	public static def downloadJre(URL src, File dest) {
 		//ant.get(src: cfg.jvmVersion.toOracleDownloadUrl(it), dest: downloaded, httpusecaches: false, skipexisting: true)
 		//URLConnection uc = src.openConnection();
 		def client = new OkHttpClient();
+		if (isHttpProxyConfigured()) {
+			int proxyPort=-1;
+			try {
+				proxyPort = Integer.valueOf(System.getProperty("http.proxyPort"))
+			} catch (NumberFormatException e) {
+				// number could not be parsed as a number.
+			}
+			if (proxyPort>=0) {
+				def proxyHost = System.getProperty("http.proxyHost")
+				def proxyAddress = InetSocketAddress.createUnresolved(proxyHost, proxyPort)
+				Proxy proxy  = new Proxy(Proxy.Type.HTTP, proxyAddress)
+				client = client.setProxy(proxy);
+			}
+		}
 		def request = new Request.Builder().url(src)
 			.addHeader("Cookie", "oraclelicense=accept-securebackup-cookie")
 			//.addHeader("Content-Type", "application/")

--- a/src/test/groovy/bundles/JreToolsTest.java
+++ b/src/test/groovy/bundles/JreToolsTest.java
@@ -1,0 +1,43 @@
+package bundles;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JreToolsTest {
+
+	private static URL GOOGLE_URL;
+
+	static {
+		try {
+			GOOGLE_URL = new URL("http://www.google.de");
+		} catch (MalformedURLException e) {
+			// noop
+		}
+	}
+	
+	@Test
+	public void shallBeAbleToObtainWebContent() {
+		File dest = createTempFileOrFail();
+				
+		JreTools.downloadJre(GOOGLE_URL, dest );
+		Assert.assertTrue("File size shall be larger than 0 bytes", 0 < dest.length());
+	}
+	
+	private File createTempFileOrFail() {
+		File dest = null;
+		try {
+			dest = File.createTempFile(getClass().getName(), ".tmp");
+		} catch (IOException e) {
+			fail("Creating a temporary file needs to succeed.");
+		}
+		return dest;
+	}
+
+}


### PR DESCRIPTION
Check whether both system properties http.proxyPort and http.proxyHost are configured. If so, configure a HTTP Proxy to download a JRE.

This solves issue #25 