### PR TITLE
Add WinLauncherName as a configuration item to allow the Windows .exe…

### DIFF
--- a/src/main/groovy/bundles/GetdownPlugin.groovy
+++ b/src/main/groovy/bundles/GetdownPlugin.groovy
@@ -138,7 +138,7 @@ class GetdownPlugin implements Plugin<Project> {
 					doFirst {
 						def getdownJar = project.configurations.getdown.resolve().iterator().next().getName()
 						def binding = ["project": project, "cfg": cfg
-							, 'outfile' : new File(cfg.dest, "launch.exe").getCanonicalPath()
+							, 'outfile' : new File(cfg.dest, cfg.winLauncherName).getCanonicalPath()
 							, jar : "app/${getdownJar}"
 							, title: cfg.title
 							, icon : new File(cfg.destApp, "favicon.ico").getCanonicalPath()

--- a/src/main/groovy/bundles/GetdownPluginExtension.groovy
+++ b/src/main/groovy/bundles/GetdownPluginExtension.groovy
@@ -56,6 +56,11 @@ class GetdownPluginExtension {
 	 *  </pre>
 	 */
 	String launch4jCmd
+	
+	/**
+	 * The name of the Windows .exe launcher e.g. "myApp.exe"
+	 */
+	String winLauncherName = "launch.exe"
 
 	/** The template used to generate the launch4j configuration */
 	String tmplLaunch4j


### PR DESCRIPTION
I wanted to be able to set the resulting Windows executable name in the build.gradle file. This allows configuration via:

`getdown {
   winLauncherName = "$project.name" + ".exe"
}`
